### PR TITLE
Edited docs/validators-and-forms.rst via GitHub

### DIFF
--- a/docs/validators-and-forms.rst
+++ b/docs/validators-and-forms.rst
@@ -877,7 +877,7 @@ the following.
 .. code-block:: text
 
     {# src/Blogger/BlogBundle/Resources/view/Page/contactEmail.txt.twig #}
-    A contact enquiry was made by {{ enquiry.name }} at {{ date("Y-m-d H:i") }}.
+    A contact enquiry was made by {{ enquiry.name }} at {{ "now" | date("Y-m-d H:i") }}.
 
     Reply-To: {{ enquiry.email }}
     Subject: {{ enquiry.subject }}


### PR DESCRIPTION
{{ date("Y-m-d H:i") }} causes an error. The right way is {{ "now" | date("Y-m-d H:i") }}
