### PR TITLE
Change requirement for comment create route to blog_id

### DIFF
--- a/docs/extending-the-model-blog-comments.rst
+++ b/docs/extending-the-model-blog-comments.rst
@@ -1082,7 +1082,7 @@ a new route to  the routing file located at
         defaults: { _controller: BloggerBlogBundle:Comment:create }
         requirements:
             _method:  POST
-            id: \d+
+            blog_id: \d+
         
 The controller
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
Noticed in Part 4 of your excellent tutorial the requirement for comment create says id instead blog_id
