### PR TITLE
Portuguese version.

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -86,6 +86,13 @@ French
 Symblog has been translated into `French <http://keiruaprod.fr/symblog-fr/>`_ thanks to the contribution by
 `Clement Keirua <https://twitter.com/clemkeirua>`_.
 
+Portuguese
+~~~~~~~~~
+
+Symblog has been translated into `Brazilian Portuguese <http://symfony2blog.totlab.com.br/>`_  thanks to the contribution by 
+`TotLab - Pesquisa e Desenvolvimento Web <http://totlab.com.br>`_.
+
+
 Author
 ------
 


### PR DESCRIPTION
Translated documentation to Brazilian Portuguese.
https://github.com/totlab/symblog-docs

As soon possible we will publish the Symblog into our domain.
