### PR TITLE
Update documentation

### DIFF
--- a/docs/doctrine-2-the-blog-model.rst
+++ b/docs/doctrine-2-the-blog-model.rst
@@ -586,7 +586,7 @@ follows.
         git=http://github.com/doctrine/data-fixtures.git
 
     [DoctrineFixturesBundle]
-        git=http://github.com/symfony/DoctrineFixturesBundle.git
+        git=http://github.com/doctrine/DoctrineFixturesBundle.git
         target=/bundles/Symfony/Bundle/DoctrineFixturesBundle
 
 Next update the vendors to reflect these changes.


### PR DESCRIPTION
The repository http://github.com/symfony/DoctrineFixturesBundle.git has been moved to http://github.com/doctrine/DoctrineFixturesBundle.git.

This commit reflects that change.

Excelent tutorial, thanks!
