### PR TITLE
Updating all getEntityManager calls to getManager

### DIFF
--- a/docs/customising-the-view-more-with-twig.rst
+++ b/docs/customising-the-view-more-with-twig.rst
@@ -258,7 +258,7 @@ action in the ``PageController`` located at
     public function sidebarAction()
     {
         $em = $this->getDoctrine()
-                   ->getEntityManager();
+                   ->getManager();
 
         $tags = $em->getRepository('BloggerBlogBundle:Blog')
                    ->getTags();

--- a/docs/doctrine-2-the-blog-model.rst
+++ b/docs/doctrine-2-the-blog-model.rst
@@ -405,7 +405,7 @@ and paste in the following.
          */
         public function showAction($id)
         {
-            $em = $this->getDoctrine()->getEntityManager();
+            $em = $this->getDoctrine()->getManager();
 
             $blog = $em->getRepository('BloggerBlogBundle:Blog')->find($id);
 

--- a/docs/extending-the-model-blog-comments.rst
+++ b/docs/extending-the-model-blog-comments.rst
@@ -47,7 +47,7 @@ to pull the blogs from the database.
         public function indexAction()
         {
             $em = $this->getDoctrine()
-                       ->getEntityManager();
+                       ->getManager();
 
             $blogs = $em->createQueryBuilder()
                         ->select('b')
@@ -313,7 +313,7 @@ Finally let's update the ``Page`` controller ``index`` action to use the ``BlogR
         public function indexAction()
         {
             $em = $this->getDoctrine()
-                       ->getEntityManager();
+                       ->getManager();
 
             $blogs = $em->getRepository('BloggerBlogBundle:Blog')
                         ->getLatestBlogs();
@@ -1126,7 +1126,7 @@ paste in the following.
         protected function getBlog($blog_id)
         {
             $em = $this->getDoctrine()
-                        ->getEntityManager();
+                        ->getManager();
 
             $blog = $em->getRepository('BloggerBlogBundle:Blog')->find($blog_id);
 
@@ -1376,7 +1376,7 @@ to the database.
 
             if ($form->isValid()) {
                 $em = $this->getDoctrine()
-                           ->getEntityManager();
+                           ->getManager();
                 $em->persist($comment);
                 $em->flush();
 


### PR DESCRIPTION
Doctrine getEntityManager function is now depricated and replaced by getManager,
updated all getEntityManager calls.
