### PR TITLE
HTML5/HTML fixes

### DIFF
--- a/docs/customising-the-view-more-with-twig.rst
+++ b/docs/customising-the-view-more-with-twig.rst
@@ -287,7 +287,7 @@ the Tag Cloud, and passes this over to the view. Now let's create this view loca
             {% for tag, weight in tags %}
                 <span class="weight-{{ weight }}">{{ tag }}</span>
             {% else %}
-                <p>There are no tags</p>
+                There are no tags
             {% endfor %}
         </p>
     </section>
@@ -460,7 +460,6 @@ with the following.
                     </p>
                 </header>
                 <p>{{ comment.comment }}</p>
-                </p>
             </article>
         {% else %}
             <p>There are no recent comments</p>


### PR DESCRIPTION
In sidebar.html.twig:
1. Unwrapped `<p>There are no tags</p>` at the "Tag Cloud" section as [p tags cannot be nested](http://stackoverflow.com/a/9852381/372654)
2. Removed the redundant `</p>` at the "Latest Comments" section
