### PR TITLE
fix caps of @ORM\PreUpdate

### DIFF
--- a/docs/extending-the-model-blog-comments.rst
+++ b/docs/extending-the-model-blog-comments.rst
@@ -404,7 +404,7 @@ paste in the following.
         }
 
         /**
-         * @ORM\preUpdate
+         * @ORM\PreUpdate
          */
         public function setUpdatedValue()
         {


### PR DESCRIPTION
current symfony2/doctrine is picky about the case:

```
$ php app/console doctrine:generate:entities 'Blogger\BlogBundle'
Generating entities for namespace "Blogger\BlogBundle"

  [Doctrine\Common\Annotations\AnnotationException]                                                                                                           
  [Semantical Error] The annotation "@Doctrine\ORM\Mapping\preUpdate" in method Blogger\BlogBundle\Entity\Comment::setUpdatedValue() does not exist, or could not be auto-loaded.                                                                                                                                       

```
