### PR TITLE
Update extending-the-model-blog-comments.rst

### DIFF
--- a/docs/customising-the-view-more-with-twig.rst
+++ b/docs/customising-the-view-more-with-twig.rst
@@ -313,7 +313,7 @@ the ``sidebar`` action of the ``Page`` controller.
     {# .. #}
 
     {% block sidebar %}
-        {% render "BloggerBlogBundle:Page:sidebar" %}
+        {{ render(controller( "BloggerBlogBundle:Page:sidebar")) }}
     {% endblock %}
 
 Finally let's add the CSS for the tag cloud. Add a new stylesheet located at

--- a/docs/extending-the-model-blog-comments.rst
+++ b/docs/extending-the-model-blog-comments.rst
@@ -1250,7 +1250,7 @@ with the following.
             {# .. #}
 
             <h3>Add Comment</h3>
-            {% render 'BloggerBlogBundle:Comment:new' with { 'blog_id': blog.id } %}
+            {{ render(controller( 'BloggerBlogBundle:Comment:new', { 'blog_id': blog.id } )) }}
         </section>
     {% endblock %}
 


### PR DESCRIPTION
fixing similar problem reported here:

https://github.com/sonata-project/SonataDoctrineORMAdminBundle/issues/166

```
Unexpected token "name" of value "with" ("end of statement block" expected) in BloggerBlogBundle:Blog:show.html.twig at line 25
```

it being related to this change: https://github.com/doctrine/DoctrineBundle/issues/141
